### PR TITLE
Improve audio detection with HPF, click fingerprint validation

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -2,124 +2,88 @@
 
 **Date**: 2025-12-05
 **Branch**: `issue-48-audio-pinch-detection`
-**Last Commit**: `f8478e4` - "Add audio-based pinch detection prototype (Issue #48)"
+**Status**: Testing audio sensitivity - ring clicks are hard to detect
 
-## Project Context
+## Problem Being Solved
 
-DhikrCounter app for Islamic prayer counting via pinch detection on Apple Watch. Phase 4 (streaming pinch detection on Watch) is complete. Template Training UI is paused (committed in `aee5842`).
+Apple Watch microphone has low sensitivity for detecting subtle finger ring clicks:
+- Baseline hovers around -68 dB
+- Ring clicks barely register above baseline
+- Tapping ring on table works, but finger-to-finger clicks don't
 
-Currently working on **Issue #48: Audio-based pinch detection** - using Watch microphone to detect click sounds from finger rings/covers.
+## Current Detection Approach (Dual Method)
 
-## Current Work: Audio Detection Prototype
+The AudioPinchDetector now uses TWO detection methods:
 
-### What Was Implemented
+1. **Threshold Method**: Signal > baseline + threshold
+2. **Jump Method (NEW)**: Sudden jump of 2+ dB from previous buffer
 
-| File | Status | Description |
-|------|--------|-------------|
-| `DhikrCounter Watch App/AudioPinchDetector.swift` | ✅ NEW | AVAudioEngine-based audio capture + onset detection |
-| `DhikrCounter Watch App/AudioTestView.swift` | ✅ NEW | Test UI with level meters and controls |
-| `DhikrCounter Watch App/Info.plist` | ✅ MODIFIED | Added NSMicrophoneUsageDescription |
-| `DhikrCounter Watch App/ContentView.swift` | ✅ MODIFIED | Added "Audio Detection Test" link in Settings |
+Either method triggers detection (OR logic).
 
-### AudioPinchDetector Features
+## Key Parameters (Current Defaults)
 
-```swift
-@MainActor
-class AudioPinchDetector: ObservableObject {
-    // Published state
-    @Published var isListening = false
-    @Published var currentRMSdB: Float = -60.0
-    @Published var baselineRMSdB: Float = -60.0
-    @Published var onsetCount: Int = 0
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `onsetThresholdDb` | 1.5 dB | Above baseline to trigger |
+| `minJumpDb` | 2.0 dB | Minimum sudden jump to trigger |
+| `refractoryPeriod` | 250 ms | Min time between detections |
+| `baselineAlpha` | 0.03 | Baseline adaptation speed |
+| `bufferSize` | 512 samples | ~10ms at 48kHz (faster response) |
 
-    // Configurable parameters
-    var onsetThresholdDb: Float = 15.0      // dB above baseline to trigger
-    var refractoryPeriod: TimeInterval = 0.25  // Min time between detections
-    var baselineAlpha: Float = 0.01         // Baseline smoothing factor
+## Baseline Adaptation (Asymmetric)
 
-    // Methods
-    func requestPermission() async -> Bool
-    func startListening()
-    func stopListening()
-    func reset()
+| Signal Level | Baseline Behavior |
+|--------------|-------------------|
+| Below baseline | Adapts quickly (normal) |
+| 0-2 dB above | Adapts quickly (normal) |
+| 2 dB to threshold | Adapts slowly (1/10th speed) |
+| Above threshold | No adaptation (ignores spikes) |
 
-    // Callback
-    var onOnsetDetected: ((Date, Float) -> Void)?
-}
-```
+## Files Modified This Session
 
-### Detection Algorithm
+| File | Changes |
+|------|---------|
+| `DhikrCounter Watch App/AudioPinchDetector.swift` | Dual detection, asymmetric baseline, smaller buffer |
+| `DhikrCounter Watch App/AudioTestView.swift` | Loads settings from iPhone, shows settings by default |
+| `DhikrCounter Watch App/WatchSessionManager.swift` | Added `getSetting()` helper, logs audio settings |
+| `DhikrCounter Watch App/ContentView.swift` | Added Audio Detection Test link in Settings |
+| `DhikrCounter Watch App/Info.plist` | Added NSMicrophoneUsageDescription |
+| `DhikrCounter/CompanionContentView.swift` | Added Audio Detection settings section |
+| `DhikrCounter/PhoneSessionManager.swift` | Added audio settings to Watch sync |
 
-1. **Audio Capture**: AVAudioEngine input tap at 48kHz, 1024-sample buffers (~21ms)
-2. **RMS Energy**: Computed via vDSP_rmsqv, converted to dB
-3. **Adaptive Baseline**: Exponential smoothing of RMS levels
-4. **Onset Detection**: Trigger when `currentRMS > baseline + threshold`
-5. **Refractory Period**: Prevent double-triggers (default 250ms)
+## iOS Settings UI
 
-### AudioTestView UI
+In iPhone app → Settings → "Audio Detection (Experimental)":
+- Toggle to enable/disable
+- Onset Threshold slider: 0.5 to 10.0 dB
+- Refractory Period slider: 100 to 500 ms
+- Must tap "Sync Now" to send to Watch
 
-- Level meter showing current vs baseline audio
-- Threshold marker (orange line)
-- Click counter (large green number)
-- Start/Stop/Reset controls
-- Settings panel for threshold and refractory tuning
+## Debug Info
 
-### How to Test
+The Watch debug log shows detection method:
+- `ONSET #1 [JUMP]: +1.5dB (jump:3.2)` - Detected by sudden jump
+- `ONSET #2 [THRESH]: +2.1dB (jump:0.5)` - Detected by threshold
 
-1. Build and deploy to **real Apple Watch** (simulator has no microphone)
-2. On Watch: Swipe down to Settings tab
-3. Tap "Audio Detection Test" (purple waveform icon)
-4. Grant microphone permission when prompted
-5. Tap "Start" to begin listening
-6. Click finger rings together - watch counter increment
+## Next Steps to Try
 
-## Recent Bug Fixes
-
-### Issue #47: Watch statistics disappears after saving session notes (MERGED)
-
-**Problem**: `watchDetectorMetadata` was lost when updating session notes
-
-**Fix**: `updateSessionNotes()` and `updateActualPinchCount()` now load full session data from disk before re-saving, preserving all fields.
-
-**PR**: #50 (merged to main)
-
-## Paused Work: Template Training UI
-
-Committed in `aee5842` on branch `phase4-watch-deployment` (merged to main).
-
-**Status**: Tap offset bug fixed but feature needs further testing.
-
-**Resume**: The template training UI allows users to mark pinch peaks in recorded sessions and create personalized templates. See previous CURRENT_STATE.md for details.
-
-## Branch Status
-
-| Branch | Status | Description |
-|--------|--------|-------------|
-| `main` | Up to date | Contains Issue #47 fix and template training WIP |
-| `issue-48-audio-pinch-detection` | Active | Audio detection prototype (ready for testing) |
-| `phase4-watch-deployment` | Merged | Template training UI (paused) |
-
-## Open Issues
-
-| # | Title | Status |
-|---|-------|--------|
-| #48 | Investigate sound addition | In progress (prototype ready) |
-| #49 | Verify event inter arrival time | Open |
-| #46 | Auto Reset count | Open |
-| #47 | Watch statistics disappears | ✅ Fixed (PR #50) |
+1. **Lower thresholds further** - Try 0.5 dB threshold, 1.0 dB jump
+2. **Different rings** - Metal rings may produce louder clicks
+3. **Ring position** - Closer to Watch microphone (inner wrist?)
+4. **Alternative approach** - Frequency-based detection instead of energy
+5. **Hybrid with motion** - Combine audio + accelerometer for confirmation
 
 ## Quick Resume Commands
 
 ```bash
 # Check current state
-git branch
 git status
 git log --oneline -5
 
-# Switch to audio detection branch
-git checkout issue-48-audio-pinch-detection
+# Current branch
+git branch  # issue-48-audio-pinch-detection
 
-# Build Watch app (use Series 11 simulator or real Watch)
+# Build Watch app
 xcodebuild -scheme "DhikrCounter Watch App" -configuration Debug \
   -destination "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)" build
 
@@ -128,36 +92,44 @@ xcodebuild -scheme "DhikrCounter" -configuration Debug \
   -destination "platform=iOS Simulator,name=iPhone 17 Pro Max" build
 ```
 
-## Next Steps
+## Uncommitted Changes
 
-1. **Test on real Watch** - Deploy to Apple Watch and test with finger rings
-2. **Tune threshold** - Adjust based on actual ring click loudness
-3. **Compare with motion** - Run sessions with both detection methods
-4. **Decide on hybrid** - Consider combining audio + motion for better accuracy
-5. **Create PR** - Once testing is satisfactory
+All changes are uncommitted. To commit:
+```bash
+git add -A
+git commit -m "Improve audio detection sensitivity with dual detection method"
+```
 
 ## Technical Notes
 
 ### watchOS Audio Constraints
-- Sample rate fixed at 48kHz (cannot change)
+- Sample rate fixed at 48kHz
+- Buffer size 512 samples = ~10.7ms per buffer
 - Must disconnect inputNode from mainMixerNode to avoid feedback
-- Use AVAudioEngine tap, not AudioUnit/AURenderCallback
-- Permission via NSMicrophoneUsageDescription in Info.plist
+- Microphone sensitivity appears quite low for subtle sounds
 
-### Simulator Limitations
-- watchOS Simulator has no real microphone
-- Must test on physical Apple Watch for audio detection
-- Motion detection works in simulator
-
-## Files Structure
-
+### Detection Algorithm Flow
 ```
-DhikrCounter Watch App/
-├── AudioPinchDetector.swift    # NEW - Audio capture + onset detection
-├── AudioTestView.swift         # NEW - Test UI for audio detection
-├── ContentView.swift           # MODIFIED - Added audio test link
-├── Info.plist                  # MODIFIED - Microphone permission
-├── DhikrDetectionEngine.swift  # Existing motion detection
-├── StreamingPinchDetector.swift # Existing streaming DSP
-└── WatchSessionManager.swift   # Watch-iPhone communication
+Audio Buffer (512 samples @ 48kHz)
+    ↓
+Compute RMS Energy (vDSP)
+    ↓
+Convert to dB: 20 * log10(rms)
+    ↓
+Update Baseline (asymmetric smoothing)
+    ↓
+Check Detection:
+  - Method 1: rmsDb > baseline + threshold?
+  - Method 2: (rmsDb - previousRmsDb) > minJumpDb?
+    ↓
+If either true AND refractory passed → ONSET DETECTED
 ```
+
+## Open Issues
+
+| # | Title | Status |
+|---|-------|--------|
+| #48 | Investigate sound addition | In progress - sensitivity issues |
+| #49 | Verify event inter arrival time | Open |
+| #46 | Auto Reset count | Open |
+| #47 | Watch statistics disappears | ✅ Fixed (PR #50) |

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,162 +1,163 @@
-# Current State: Template Training UI Implementation
+# Current State: Audio-Based Pinch Detection Prototype
 
-**Date**: 2025-11-26
-**Branch**: `phase4-watch-deployment`
-**Last Commit**: `5b510ed` - "Update CURRENT_STATE.md with Phase 4 completion status"
+**Date**: 2025-12-05
+**Branch**: `issue-48-audio-pinch-detection`
+**Last Commit**: `f8478e4` - "Add audio-based pinch detection prototype (Issue #48)"
 
 ## Project Context
-DhikrCounter app for Islamic prayer counting via pinch detection on Apple Watch. Phase 4 (streaming pinch detection on Watch) is complete. Currently implementing **User-Assisted Template Training** (Option 4) to allow users to label pinch peaks in recorded sessions and create personalized templates.
 
-## Current Work: Template Training UI
+DhikrCounter app for Islamic prayer counting via pinch detection on Apple Watch. Phase 4 (streaming pinch detection on Watch) is complete. Template Training UI is paused (committed in `aee5842`).
+
+Currently working on **Issue #48: Audio-based pinch detection** - using Watch microphone to detect click sounds from finger rings/covers.
+
+## Current Work: Audio Detection Prototype
 
 ### What Was Implemented
 
 | File | Status | Description |
 |------|--------|-------------|
-| `DhikrCounter/TemplateTrainingView.swift` | ✅ NEW | Full-screen peak labeling UI (~1000 lines) |
-| `DhikrCounter/DataVisualizationView.swift` | ✅ MODIFIED | Added "Train Templates" button |
-| `DhikrCounter/CompanionContentView.swift` | ✅ MODIFIED | Added "Saved Templates" navigation link |
-| `DhikrCounter/PhoneSessionManager.swift` | ✅ MODIFIED | Added `sendTrainedTemplates()` for Watch sync |
-| `DhikrCounter Watch App/WatchSessionManager.swift` | ✅ MODIFIED | Added file receive handler for templates |
-| `Shared/PinchTypes.swift` | ✅ MODIFIED | Loads user templates first before bundle defaults |
+| `DhikrCounter Watch App/AudioPinchDetector.swift` | ✅ NEW | AVAudioEngine-based audio capture + onset detection |
+| `DhikrCounter Watch App/AudioTestView.swift` | ✅ NEW | Test UI with level meters and controls |
+| `DhikrCounter Watch App/Info.plist` | ✅ MODIFIED | Added NSMicrophoneUsageDescription |
+| `DhikrCounter Watch App/ContentView.swift` | ✅ MODIFIED | Added "Audio Detection Test" link in Settings |
 
-### Key Components in TemplateTrainingView.swift
+### AudioPinchDetector Features
 
 ```swift
-// Data structures
-struct LabeledPeak: Identifiable, Codable {
-    let id: UUID
-    let timestamp: TimeInterval
-    let peakIndex: Int
-    var isConfirmed: Bool
-    let positionContext: String?
-}
+@MainActor
+class AudioPinchDetector: ObservableObject {
+    // Published state
+    @Published var isListening = false
+    @Published var currentRMSdB: Float = -60.0
+    @Published var baselineRMSdB: Float = -60.0
+    @Published var onsetCount: Int = 0
 
-struct TrainedTemplateSet: Identifiable, Codable {
-    let id: UUID
-    let sourceSessionId: String
-    let createdDate: Date
-    let positionContext: String
-    let templateCount: Int
-    let templates: [[Float]]
-    let amplitudeSurplusThresholds: [Float]
-}
+    // Configurable parameters
+    var onsetThresholdDb: Float = 15.0      // dB above baseline to trigger
+    var refractoryPeriod: TimeInterval = 0.25  // Min time between detections
+    var baselineAlpha: Float = 0.01         // Baseline smoothing factor
 
-// Main manager singleton
-class TemplateTrainingManager: ObservableObject {
-    static let shared = TemplateTrainingManager()
-    @Published var labeledPeaks: [LabeledPeak] = []
-    @Published var trainedTemplateSets: [TrainedTemplateSet] = []
+    // Methods
+    func requestPermission() async -> Bool
+    func startListening()
+    func stopListening()
+    func reset()
 
-    func extractTemplates(from sensorData: [SensorReading], sessionId: String, userMarks: [LabeledPeak], fs: Float = 50.0) -> TrainedTemplateSet?
-    func syncToWatch()
-    func exportForWatch() -> Data?
+    // Callback
+    var onOnsetDetected: ((Date, Float) -> Void)?
 }
 ```
 
-### UI Features
+### Detection Algorithm
 
-1. **Full-Screen Peak Labeler** (`FullScreenPeakLabeler`)
-   - Pinch-to-zoom (1x to 30x)
-   - Two-finger pan when zoomed
-   - Fixed Y-axis scale for consistent comparison
-   - Threshold slider to filter noise (percentile-based)
-   - Auto-detected peaks shown as gray diamonds
-   - User-confirmed peaks shown as green circles with timestamps
+1. **Audio Capture**: AVAudioEngine input tap at 48kHz, 1024-sample buffers (~21ms)
+2. **RMS Energy**: Computed via vDSP_rmsqv, converted to dB
+3. **Adaptive Baseline**: Exponential smoothing of RMS levels
+4. **Onset Detection**: Trigger when `currentRMS > baseline + threshold`
+5. **Refractory Period**: Prevent double-triggers (default 250ms)
 
-2. **Tap Gesture Handling** (uses `ChartProxy` for accurate coordinates)
-   - Tap gray diamond → Confirm auto-detected peak
-   - Tap green circle → Remove confirmed peak
-   - Tap elsewhere above threshold → Add new mark (snaps to local maximum)
+### AudioTestView UI
 
-3. **Template Extraction**
-   - Extracts 25-sample windows around marked peaks
-   - Z-normalizes templates
-   - Computes amplitude surplus thresholds
-   - Requires minimum 3 valid marks
+- Level meter showing current vs baseline audio
+- Threshold marker (orange line)
+- Click counter (large green number)
+- Start/Stop/Reset controls
+- Settings panel for threshold and refractory tuning
 
-4. **Watch Sync**
-   - Templates saved to `trained_templates.json`
-   - Transferred via WatchConnectivity `transferFile()`
-   - Watch loads user templates before bundle defaults
+### How to Test
 
-### Bug Fixed This Session
+1. Build and deploy to **real Apple Watch** (simulator has no microphone)
+2. On Watch: Swipe down to Settings tab
+3. Tap "Audio Detection Test" (purple waveform icon)
+4. Grant microphone permission when prompted
+5. Tap "Start" to begin listening
+6. Click finger rings together - watch counter increment
 
-**Tap Offset Bug**: User had to tap to the RIGHT of peaks to select them.
+## Recent Bug Fixes
 
-**Root Cause**: The tap coordinate transformation used `location.x / chartWidth` which didn't account for Y-axis label space.
+### Issue #47: Watch statistics disappears after saving session notes (MERGED)
 
-**Fix**: Used SwiftUI Charts' `ChartProxy.value(atX:)` method which properly converts screen coordinates to data values:
+**Problem**: `watchDetectorMetadata` was lost when updating session notes
 
-```swift
-// OLD (incorrect)
-let tapRatio = location.x / chartWidth
-let tappedIndex = visibleStartIndex + Int(CGFloat(visibleSamples) * tapRatio)
+**Fix**: `updateSessionNotes()` and `updateActualPinchCount()` now load full session data from disk before re-saving, preserving all fields.
 
-// NEW (correct)
-.chartOverlay { proxy in
-    GeometryReader { geometry in
-        Rectangle()
-            .fill(Color.clear)
-            .contentShape(Rectangle())
-            .onTapGesture { location in
-                guard let tappedXValue: Int = proxy.value(atX: location.x) else { return }
-                // tappedXValue is now the correct sample index
-            }
-    }
-}
-```
+**PR**: #50 (merged to main)
 
-### Build Status
-- ✅ iOS target compiles successfully (iPhone 16 Pro simulator)
+## Paused Work: Template Training UI
 
-## Phase 4 Summary (Completed Previously)
+Committed in `aee5842` on branch `phase4-watch-deployment` (merged to main).
 
-- StreamingPinchDetector deployed to Apple Watch
-- Single-sample processing API
-- Causal filtering, TKEO, L2 sensor fusion
-- Template validation with NCC
-- Quality gates: amplitude surplus, ISI, gyro veto
-- Pending hardware validation on real Watch
+**Status**: Tap offset bug fixed but feature needs further testing.
 
-## Testing Configuration
+**Resume**: The template training UI allows users to mark pinch peaks in recorded sessions and create personalized templates. See previous CURRENT_STATE.md for details.
 
-**iPhone Simulator**: iPhone 16 Pro Max (has existing session data)
-**Watch Hardware**: Real Apple Watch for hardware testing
+## Branch Status
+
+| Branch | Status | Description |
+|--------|--------|-------------|
+| `main` | Up to date | Contains Issue #47 fix and template training WIP |
+| `issue-48-audio-pinch-detection` | Active | Audio detection prototype (ready for testing) |
+| `phase4-watch-deployment` | Merged | Template training UI (paused) |
+
+## Open Issues
+
+| # | Title | Status |
+|---|-------|--------|
+| #48 | Investigate sound addition | In progress (prototype ready) |
+| #49 | Verify event inter arrival time | Open |
+| #46 | Auto Reset count | Open |
+| #47 | Watch statistics disappears | ✅ Fixed (PR #50) |
 
 ## Quick Resume Commands
 
 ```bash
-# Check current branch and status
+# Check current state
 git branch
 git status
+git log --oneline -5
+
+# Switch to audio detection branch
+git checkout issue-48-audio-pinch-detection
+
+# Build Watch app (use Series 11 simulator or real Watch)
+xcodebuild -scheme "DhikrCounter Watch App" -configuration Debug \
+  -destination "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)" build
 
 # Build iOS app
 xcodebuild -scheme "DhikrCounter" -configuration Debug \
-  -destination "platform=iOS Simulator,name=iPhone 16 Pro" build
-
-# Build Watch app
-xcodebuild -scheme "DhikrCounter Watch App" -configuration Debug \
-  -destination "platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)" build
+  -destination "platform=iOS Simulator,name=iPhone 17 Pro Max" build
 ```
 
 ## Next Steps
 
-1. **Test Template Training UI** - Verify tap accuracy after the fix
-2. **Train Templates** - Use the UI to mark peaks in a recorded session
-3. **Sync to Watch** - Transfer trained templates via WatchConnectivity
-4. **Validate Detection** - Test if personalized templates improve detection accuracy
-5. **Git Commit** - Commit template training implementation when complete
+1. **Test on real Watch** - Deploy to Apple Watch and test with finger rings
+2. **Tune threshold** - Adjust based on actual ring click loudness
+3. **Compare with motion** - Run sessions with both detection methods
+4. **Decide on hybrid** - Consider combining audio + motion for better accuracy
+5. **Create PR** - Once testing is satisfactory
 
-## Files Modified (Uncommitted)
+## Technical Notes
 
-- `DhikrCounter/TemplateTrainingView.swift` - Tap offset bug fix
-- `CURRENT_STATE.md` - This file
+### watchOS Audio Constraints
+- Sample rate fixed at 48kHz (cannot change)
+- Must disconnect inputNode from mainMixerNode to avoid feedback
+- Use AVAudioEngine tap, not AudioUnit/AURenderCallback
+- Permission via NSMicrophoneUsageDescription in Info.plist
 
-## Notes
+### Simulator Limitations
+- watchOS Simulator has no real microphone
+- Must test on physical Apple Watch for audio detection
+- Motion detection works in simulator
 
-- User selected Option 4 (User-Assisted Labeling) for template training
-- Full-screen landscape view preferred for dense signal data
-- Threshold filter helps reduce noise before marking
-- Auto-detected peaks provide reference points to reduce manual marking
-- Templates use Z-normalization for scale invariance
+## Files Structure
+
+```
+DhikrCounter Watch App/
+├── AudioPinchDetector.swift    # NEW - Audio capture + onset detection
+├── AudioTestView.swift         # NEW - Test UI for audio detection
+├── ContentView.swift           # MODIFIED - Added audio test link
+├── Info.plist                  # MODIFIED - Microphone permission
+├── DhikrDetectionEngine.swift  # Existing motion detection
+├── StreamingPinchDetector.swift # Existing streaming DSP
+└── WatchSessionManager.swift   # Watch-iPhone communication
+```

--- a/DhikrCounter Watch App/AudioPinchDetector.swift
+++ b/DhikrCounter Watch App/AudioPinchDetector.swift
@@ -1,0 +1,282 @@
+import Foundation
+import AVFoundation
+import Accelerate
+
+/// Audio-based pinch detection using Apple Watch microphone
+/// Detects sudden onset sounds (clicks/taps) from finger rings or covers
+@MainActor
+class AudioPinchDetector: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published var isListening = false
+    @Published var currentRMSdB: Float = -60.0
+    @Published var baselineRMSdB: Float = -60.0
+    @Published var lastOnsetTime: Date?
+    @Published var onsetCount: Int = 0
+    @Published var debugLog: [String] = []
+
+    // MARK: - Audio Engine
+
+    private var audioEngine: AVAudioEngine?
+    private let audioQueue = DispatchQueue(label: "com.dhikrcounter.audio", qos: .userInteractive)
+
+    // MARK: - Detection Parameters
+
+    /// Threshold above baseline (in dB) to trigger onset detection
+    var onsetThresholdDb: Float = 15.0
+
+    /// Minimum time between detections (seconds)
+    var refractoryPeriod: TimeInterval = 0.25
+
+    /// Smoothing factor for baseline (0-1, lower = slower adaptation)
+    var baselineAlpha: Float = 0.01
+
+    /// Buffer size for audio tap (samples)
+    let bufferSize: AVAudioFrameCount = 1024
+
+    // MARK: - Internal State
+
+    private var lastOnsetTimestamp: TimeInterval = 0
+    private var runningBaseline: Float = -60.0
+    private var isInitialized = false
+
+    // MARK: - Callbacks
+
+    /// Called when an onset (click sound) is detected
+    var onOnsetDetected: ((Date, Float) -> Void)?
+
+    // MARK: - Initialization
+
+    init() {
+        addDebug("AudioPinchDetector initialized")
+    }
+
+    deinit {
+        // Clean up audio engine directly since we can't call MainActor methods in deinit
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+    }
+
+    // MARK: - Public Methods
+
+    /// Request microphone permission
+    func requestPermission() async -> Bool {
+        addDebug("Requesting microphone permission...")
+
+        if #available(watchOS 10.0, *) {
+            let status = AVAudioApplication.shared.recordPermission
+
+            switch status {
+            case .granted:
+                addDebug("Microphone permission already granted")
+                return true
+            case .denied:
+                addDebug("Microphone permission denied")
+                return false
+            case .undetermined:
+                addDebug("Requesting microphone permission from user...")
+                let granted = await AVAudioApplication.requestRecordPermission()
+                addDebug("Permission result: \(granted)")
+                return granted
+            @unknown default:
+                addDebug("Unknown permission status")
+                return false
+            }
+        } else {
+            // Fallback for older watchOS
+            return await withCheckedContinuation { continuation in
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    Task { @MainActor in
+                        self.addDebug("Permission result (legacy): \(granted)")
+                    }
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    /// Start listening for audio onset events
+    func startListening() {
+        guard !isListening else {
+            addDebug("Already listening")
+            return
+        }
+
+        addDebug("Starting audio capture...")
+
+        audioQueue.async { [weak self] in
+            self?.setupAndStartAudioEngine()
+        }
+    }
+
+    /// Stop listening
+    func stopListening() {
+        guard isListening else { return }
+
+        addDebug("Stopping audio capture...")
+
+        audioQueue.async { [weak self] in
+            self?.teardownAudioEngine()
+        }
+    }
+
+    /// Reset detection state
+    func reset() {
+        onsetCount = 0
+        lastOnsetTime = nil
+        lastOnsetTimestamp = 0
+        runningBaseline = -60.0
+        debugLog.removeAll()
+        addDebug("Detector reset")
+    }
+
+    // MARK: - Audio Engine Setup
+
+    private func setupAndStartAudioEngine() {
+        do {
+            // Configure audio session
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .measurement, options: [])
+            try session.setActive(true)
+
+            // Create audio engine
+            let engine = AVAudioEngine()
+            let inputNode = engine.inputNode
+
+            // Get hardware format
+            let hwFormat = inputNode.outputFormat(forBus: 0)
+
+            Task { @MainActor in
+                self.addDebug("Audio format: \(hwFormat.sampleRate) Hz, \(hwFormat.channelCount) ch")
+            }
+
+            // Install tap on input node
+            // Important: On watchOS, we tap directly on inputNode without connecting to mixer
+            inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: hwFormat) { [weak self] buffer, time in
+                self?.processAudioBuffer(buffer, time: time)
+            }
+
+            // Start engine
+            try engine.start()
+
+            self.audioEngine = engine
+            self.isInitialized = true
+
+            Task { @MainActor in
+                self.isListening = true
+                self.addDebug("Audio engine started successfully")
+            }
+
+        } catch {
+            Task { @MainActor in
+                self.addDebug("Failed to start audio engine: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func teardownAudioEngine() {
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        isInitialized = false
+
+        Task { @MainActor in
+            self.isListening = false
+            self.addDebug("Audio engine stopped")
+        }
+    }
+
+    // MARK: - Audio Processing
+
+    private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, time: AVAudioTime) {
+        guard let channelData = buffer.floatChannelData else { return }
+
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return }
+
+        // Compute RMS of the buffer
+        let samples = channelData[0]
+        var rms: Float = 0
+        vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frameLength))
+
+        // Convert to dB
+        let rmsDb = 20 * log10(max(rms, 1e-10))
+
+        // Update baseline with exponential smoothing
+        if runningBaseline < -59.0 {
+            // Initialize baseline
+            runningBaseline = rmsDb
+        } else {
+            runningBaseline = baselineAlpha * rmsDb + (1 - baselineAlpha) * runningBaseline
+        }
+
+        // Check for onset
+        let currentTime = Date().timeIntervalSince1970
+        let timeSinceLastOnset = currentTime - lastOnsetTimestamp
+        let threshold = runningBaseline + onsetThresholdDb
+
+        let isOnset = rmsDb > threshold && timeSinceLastOnset > refractoryPeriod
+
+        // Update UI on main thread
+        Task { @MainActor in
+            self.currentRMSdB = rmsDb
+            self.baselineRMSdB = self.runningBaseline
+
+            if isOnset {
+                self.lastOnsetTimestamp = currentTime
+                self.onsetCount += 1
+                self.lastOnsetTime = Date()
+
+                let spikeDb = rmsDb - self.runningBaseline
+                self.addDebug(String(format: "ONSET #%d: %.1f dB above baseline", self.onsetCount, spikeDb))
+
+                // Fire callback
+                self.onOnsetDetected?(Date(), spikeDb)
+            }
+        }
+    }
+
+    // MARK: - Debug Logging
+
+    private func addDebug(_ message: String) {
+        let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
+        let entry = "[\(timestamp)] \(message)"
+
+        if Thread.isMainThread {
+            debugLog.append(entry)
+            if debugLog.count > 100 {
+                debugLog.removeFirst()
+            }
+        } else {
+            Task { @MainActor in
+                self.debugLog.append(entry)
+                if self.debugLog.count > 100 {
+                    self.debugLog.removeFirst()
+                }
+            }
+        }
+
+        print("AudioPinchDetector: \(message)")
+    }
+}
+
+// MARK: - Audio Event Structure
+
+/// Represents a detected audio onset event
+struct AudioOnsetEvent: Codable, Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let epochTime: TimeInterval
+    let amplitudeDb: Float
+    let spikeAboveBaselineDb: Float
+
+    init(timestamp: Date = Date(), amplitudeDb: Float, spikeDb: Float) {
+        self.id = UUID()
+        self.timestamp = timestamp
+        self.epochTime = timestamp.timeIntervalSince1970
+        self.amplitudeDb = amplitudeDb
+        self.spikeAboveBaselineDb = spikeDb
+    }
+}

--- a/DhikrCounter Watch App/AudioPinchDetector.swift
+++ b/DhikrCounter Watch App/AudioPinchDetector.swift
@@ -24,16 +24,84 @@ class AudioPinchDetector: ObservableObject {
     // MARK: - Detection Parameters
 
     /// Threshold above baseline (in dB) to trigger onset detection
-    var onsetThresholdDb: Float = 15.0
+    /// With AND logic, can be lower since jump threshold provides additional filtering
+    var onsetThresholdDb: Float = 8.0
 
     /// Minimum time between detections (seconds)
     var refractoryPeriod: TimeInterval = 0.25
 
-    /// Smoothing factor for baseline (0-1, lower = slower adaptation)
-    var baselineAlpha: Float = 0.01
+    /// Smoothing factor for baseline adaptation (0-1)
+    /// Higher = faster recovery after noise spikes
+    var baselineAlpha: Float = 0.03
 
-    /// Buffer size for audio tap (samples)
-    let bufferSize: AVAudioFrameCount = 1024
+    /// Don't let spikes raise the baseline - use asymmetric smoothing
+    var useAsymmetricBaseline: Bool = true
+
+    /// Buffer size for audio tap (samples) - smaller = faster response
+    let bufferSize: AVAudioFrameCount = 512
+
+    // MARK: - Peak Detection State
+
+    /// Track the previous RMS for derivative-based detection
+    private var previousRmsDb: Float = -60.0
+
+    /// Minimum jump in dB from one buffer to next to count as onset
+    /// Based on testing: real clicks show 15-30 dB jumps, noise shows 2-7 dB
+    var minJumpDb: Float = 10.0
+
+    /// Maximum spike above baseline (dB) to accept as a click
+    /// Spikes louder than this are likely ambient noise (door slam, cough, loud voice)
+    /// Ring clicks are typically +15-30 dB; loud ambient can be +35-50 dB
+    var maxSpikeDb: Float = 35.0
+
+    // MARK: - High-Pass Filter State
+
+    /// Biquad filter state (z^-1 and z^-2 for input and output)
+    /// Must persist between buffers to avoid discontinuities
+    private var hpfState: (x1: Float, x2: Float, y1: Float, y2: Float) = (0, 0, 0, 0)
+
+    /// High-pass filter coefficients for ~3kHz cutoff @ 48kHz sample rate
+    /// Butterworth 2nd order HPF - generated using standard biquad formula
+    /// These coefficients filter out low-frequency ambient noise while preserving
+    /// the high-frequency content of ring clicks (typically 2-8 kHz)
+    private let hpfB0: Float = 0.7328934    // Feedforward coefficient b0
+    private let hpfB1: Float = -1.4657868   // Feedforward coefficient b1
+    private let hpfB2: Float = 0.7328934    // Feedforward coefficient b2
+    private let hpfA1: Float = -1.3965850   // Feedback coefficient a1
+    private let hpfA2: Float = 0.5349886    // Feedback coefficient a2
+
+    /// Enable/disable high-pass filtering (for A/B testing)
+    var useHighPassFilter: Bool = true
+
+    // MARK: - Click Fingerprint Validation State
+
+    /// Tracks a pending spike that needs decay validation
+    /// A click must: spike up quickly, then decay quickly (unlike voice which stays elevated)
+    private var pendingSpike: PendingSpike?
+
+    /// How many buffers to wait for decay validation (~50ms = 4-5 buffers at 512 samples/48kHz)
+    var decayCheckBuffers: Int = 5
+
+    /// Signal must drop below (baseline + this) to confirm decay
+    var decayThresholdDb: Float = 5.0
+
+    /// Maximum buffers the signal can stay elevated before rejecting as voice (~100ms max)
+    var maxElevatedBuffers: Int = 10
+
+    /// Counter for how many consecutive buffers signal has been elevated
+    private var elevatedBufferCount: Int = 0
+
+    /// Flag to wait for signal to return to baseline after voice rejection
+    /// Prevents immediate re-triggering while signal is still elevated
+    private var waitingForBaseline: Bool = false
+
+    /// Structure to track a spike pending validation
+    private struct PendingSpike {
+        let timestamp: Date
+        let spikeDb: Float
+        let jump: Float
+        var buffersWaited: Int = 0
+    }
 
     // MARK: - Internal State
 
@@ -128,8 +196,13 @@ class AudioPinchDetector: ObservableObject {
         lastOnsetTime = nil
         lastOnsetTimestamp = 0
         runningBaseline = -60.0
+        previousRmsDb = -60.0
+        pendingSpike = nil
+        elevatedBufferCount = 0
+        waitingForBaseline = false
+        resetHighPassFilter()  // Reset HPF state to avoid artifacts
         debugLog.removeAll()
-        addDebug("Detector reset")
+        addDebug("Detector reset (HPF: \(useHighPassFilter ? "ON" : "OFF"))")
     }
 
     // MARK: - Audio Engine Setup
@@ -188,6 +261,49 @@ class AudioPinchDetector: ObservableObject {
         }
     }
 
+    // MARK: - High-Pass Filter
+
+    /// Apply 2nd order Butterworth high-pass filter to isolate high-frequency click sounds
+    /// This filters out low-frequency ambient noise (body movement, AC hum, etc.)
+    /// while preserving the sharp transients from ring clicks (typically 2-8 kHz)
+    ///
+    /// Expected effect: Baseline drops from ~-68dB to ~-85dB, effectively +15-20dB sensitivity
+    private func applyHighPassFilter(_ samples: UnsafePointer<Float>, count: Int) -> [Float] {
+        var output = [Float](repeating: 0, count: count)
+
+        // Direct Form II Biquad implementation
+        // y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] - a1*y[n-1] - a2*y[n-2]
+        var x1 = hpfState.x1
+        var x2 = hpfState.x2
+        var y1 = hpfState.y1
+        var y2 = hpfState.y2
+
+        for i in 0..<count {
+            let x0 = samples[i]
+
+            // Compute filtered output
+            let y0 = hpfB0 * x0 + hpfB1 * x1 + hpfB2 * x2 - hpfA1 * y1 - hpfA2 * y2
+
+            output[i] = y0
+
+            // Shift state
+            x2 = x1
+            x1 = x0
+            y2 = y1
+            y1 = y0
+        }
+
+        // Persist state for next buffer (critical to avoid discontinuities!)
+        hpfState = (x1, x2, y1, y2)
+
+        return output
+    }
+
+    /// Reset filter state (call when stopping/restarting detection)
+    private func resetHighPassFilter() {
+        hpfState = (0, 0, 0, 0)
+    }
+
     // MARK: - Audio Processing
 
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer, time: AVAudioTime) {
@@ -196,44 +312,155 @@ class AudioPinchDetector: ObservableObject {
         let frameLength = Int(buffer.frameLength)
         guard frameLength > 0 else { return }
 
-        // Compute RMS of the buffer
         let samples = channelData[0]
-        var rms: Float = 0
-        vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frameLength))
 
-        // Convert to dB
-        let rmsDb = 20 * log10(max(rms, 1e-10))
+        // Compute signal level - either with HPF or raw
+        let signalDb: Float
+        if useHighPassFilter {
+            // NEW APPROACH: High-pass filter + Peak detection
+            // 1. Apply HPF to isolate high-frequency click sounds (removes ambient noise)
+            let filtered = applyHighPassFilter(samples, count: frameLength)
 
-        // Update baseline with exponential smoothing
-        if runningBaseline < -59.0 {
-            // Initialize baseline
-            runningBaseline = rmsDb
+            // 2. Use PEAK detection instead of RMS
+            // A 0.5ms click gets diluted by ~20x in a 10.7ms RMS window
+            // Peak detection finds the actual spike
+            var peak: Float = 0
+            filtered.withUnsafeBufferPointer { ptr in
+                vDSP_maxmgv(ptr.baseAddress!, 1, &peak, vDSP_Length(frameLength))
+            }
+
+            // Convert peak to dB
+            signalDb = 20 * log10(max(peak, 1e-10))
         } else {
-            runningBaseline = baselineAlpha * rmsDb + (1 - baselineAlpha) * runningBaseline
+            // OLD APPROACH: Broadband RMS (for A/B comparison)
+            var rms: Float = 0
+            vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frameLength))
+            signalDb = 20 * log10(max(rms, 1e-10))
         }
 
-        // Check for onset
+        // Update baseline with asymmetric smoothing
+        // Fast decay when quiet, slow rise when loud (to adapt to ambient noise changes)
+        if runningBaseline < -90.0 {
+            // Initialize baseline
+            runningBaseline = signalDb
+        } else if useAsymmetricBaseline {
+            let aboveBaseline = signalDb - runningBaseline
+
+            if aboveBaseline < 2.0 {
+                // Signal is at or below baseline - adapt quickly (normal alpha)
+                runningBaseline = baselineAlpha * signalDb + (1 - baselineAlpha) * runningBaseline
+            } else if aboveBaseline < onsetThresholdDb {
+                // Signal is elevated but below detection threshold
+                // Adapt slowly upward (1/10th speed) to handle ambient noise increase
+                let slowAlpha = baselineAlpha * 0.1
+                runningBaseline = slowAlpha * signalDb + (1 - slowAlpha) * runningBaseline
+            }
+            // If signal is above threshold (actual spike), don't update baseline
+        } else {
+            // Symmetric smoothing (old behavior)
+            runningBaseline = baselineAlpha * signalDb + (1 - baselineAlpha) * runningBaseline
+        }
+
+        // Check for onset using TWO methods:
+        // 1. Absolute: signal above baseline + threshold
+        // 2. Derivative: sudden jump from previous buffer
         let currentTime = Date().timeIntervalSince1970
         let timeSinceLastOnset = currentTime - lastOnsetTimestamp
         let threshold = runningBaseline + onsetThresholdDb
+        let decayLevel = runningBaseline + decayThresholdDb
 
-        let isOnset = rmsDb > threshold && timeSinceLastOnset > refractoryPeriod
+        // Method 1: Above absolute threshold
+        let aboveThreshold = signalDb > threshold
+
+        // Method 2: Sudden jump (derivative)
+        let jump = signalDb - previousRmsDb
+        let suddenJump = jump > minJumpDb
+
+        // Track if signal is currently elevated (for duration checking)
+        let isElevated = signalDb > decayLevel
+
+        // Store for next iteration
+        previousRmsDb = signalDb
+
+        // ============================================================
+        // CLICK FINGERPRINT VALIDATION
+        // A real click: spikes up instantly, decays within ~50-100ms
+        // Voice/sustained sounds: rise gradually, stay elevated
+        // ============================================================
 
         // Update UI on main thread
         Task { @MainActor in
-            self.currentRMSdB = rmsDb
+            self.currentRMSdB = signalDb
             self.baselineRMSdB = self.runningBaseline
 
-            if isOnset {
-                self.lastOnsetTimestamp = currentTime
-                self.onsetCount += 1
-                self.lastOnsetTime = Date()
+            // STATE MACHINE for click validation
+            if let pending = self.pendingSpike {
+                // We have a pending spike - check if it decayed (confirming it's a click)
+                var updatedPending = pending
+                updatedPending.buffersWaited += 1
 
-                let spikeDb = rmsDb - self.runningBaseline
-                self.addDebug(String(format: "ONSET #%d: %.1f dB above baseline", self.onsetCount, spikeDb))
+                if !isElevated {
+                    // Signal dropped back down - this IS a click!
+                    // Confirm the detection
+                    if timeSinceLastOnset > self.refractoryPeriod {
+                        self.lastOnsetTimestamp = currentTime
+                        self.onsetCount += 1
+                        self.lastOnsetTime = Date()
 
-                // Fire callback
-                self.onOnsetDetected?(Date(), spikeDb)
+                        let filterMode = self.useHighPassFilter ? "HPF" : "RAW"
+                        self.addDebug(String(format: "CLICK #%d [%@]: +%.1fdB (jump:%.1f, decay:%d bufs)",
+                                             self.onsetCount, filterMode, pending.spikeDb, pending.jump, updatedPending.buffersWaited))
+
+                        // Fire callback
+                        self.onOnsetDetected?(pending.timestamp, pending.spikeDb)
+                    }
+                    self.pendingSpike = nil
+                    self.elevatedBufferCount = 0
+
+                } else if updatedPending.buffersWaited >= self.maxElevatedBuffers {
+                    // Signal stayed elevated too long - reject as voice/sustained sound
+                    self.addDebug(String(format: "REJECTED [VOICE]: +%.1fdB stayed elevated %d buffers",
+                                         pending.spikeDb, updatedPending.buffersWaited))
+                    self.pendingSpike = nil
+                    self.elevatedBufferCount = 0
+                    // IMPORTANT: Wait for signal to return to baseline before accepting new spikes
+                    self.waitingForBaseline = true
+
+                } else {
+                    // Still waiting for decay
+                    self.pendingSpike = updatedPending
+                    self.elevatedBufferCount += 1
+                }
+
+            } else if self.waitingForBaseline {
+                // After voice rejection, wait for signal to drop before accepting new spikes
+                if !isElevated {
+                    self.waitingForBaseline = false
+                    // Now ready to detect new clicks
+                }
+                // Otherwise keep waiting silently
+
+            } else if aboveThreshold && suddenJump && timeSinceLastOnset > self.refractoryPeriod {
+                // New potential spike detected - start validation
+                let spikeDb = signalDb - self.runningBaseline
+
+                // Check if spike is TOO LOUD (ambient noise like door slam, cough)
+                if spikeDb > self.maxSpikeDb {
+                    self.addDebug(String(format: "REJECTED [TOO LOUD]: +%.1fdB > max %.0fdB",
+                                         spikeDb, self.maxSpikeDb))
+                    // Don't even start validation - immediately reject
+                    // Also wait for baseline to prevent rapid re-triggering
+                    self.waitingForBaseline = true
+                } else {
+                    // Valid range - start decay validation
+                    self.pendingSpike = PendingSpike(
+                        timestamp: Date(),
+                        spikeDb: spikeDb,
+                        jump: jump
+                    )
+                    self.elevatedBufferCount = 1
+                    // Don't count yet - wait for decay validation
+                }
             }
         }
     }

--- a/DhikrCounter Watch App/AudioTestView.swift
+++ b/DhikrCounter Watch App/AudioTestView.swift
@@ -1,0 +1,271 @@
+import SwiftUI
+
+/// Test view for audio-based pinch detection
+/// Use this to experiment with microphone-based click detection
+struct AudioTestView: View {
+    @StateObject private var audioDetector = AudioPinchDetector()
+    @State private var permissionGranted = false
+    @State private var showingSettings = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                // Status indicator
+                statusSection
+
+                // Level meters
+                if audioDetector.isListening {
+                    levelMetersSection
+                }
+
+                // Detection count
+                detectionSection
+
+                // Controls
+                controlsSection
+
+                // Settings
+                if showingSettings {
+                    settingsSection
+                }
+            }
+            .padding(.horizontal, 8)
+        }
+        .navigationTitle("Audio Test")
+        .task {
+            permissionGranted = await audioDetector.requestPermission()
+        }
+    }
+
+    // MARK: - Status Section
+
+    private var statusSection: some View {
+        HStack {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 12, height: 12)
+
+            Text(statusText)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            Button {
+                showingSettings.toggle()
+            } label: {
+                Image(systemName: "gear")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        if !permissionGranted {
+            return .red
+        } else if audioDetector.isListening {
+            return .green
+        } else {
+            return .yellow
+        }
+    }
+
+    private var statusText: String {
+        if !permissionGranted {
+            return "No microphone access"
+        } else if audioDetector.isListening {
+            return "Listening..."
+        } else {
+            return "Ready"
+        }
+    }
+
+    // MARK: - Level Meters
+
+    private var levelMetersSection: some View {
+        VStack(spacing: 8) {
+            // Current level
+            LevelMeter(
+                label: "Level",
+                valueDb: audioDetector.currentRMSdB,
+                minDb: -60,
+                maxDb: 0,
+                thresholdDb: audioDetector.baselineRMSdB + audioDetector.onsetThresholdDb
+            )
+
+            // Baseline + threshold indicator
+            HStack {
+                Text("Baseline:")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                Text(String(format: "%.0f dB", audioDetector.baselineRMSdB))
+                    .font(.system(size: 10, design: .monospaced))
+
+                Spacer()
+
+                Text("Threshold:")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                Text(String(format: "+%.0f dB", audioDetector.onsetThresholdDb))
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(.orange)
+            }
+        }
+        .padding(8)
+        .background(Color(.darkGray).opacity(0.3))
+        .cornerRadius(8)
+    }
+
+    // MARK: - Detection Section
+
+    private var detectionSection: some View {
+        VStack(spacing: 4) {
+            Text("\(audioDetector.onsetCount)")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundColor(.green)
+
+            Text("clicks detected")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+
+            if let lastTime = audioDetector.lastOnsetTime {
+                Text("Last: \(lastTime, style: .time)")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Controls Section
+
+    private var controlsSection: some View {
+        HStack(spacing: 12) {
+            Button {
+                if audioDetector.isListening {
+                    audioDetector.stopListening()
+                } else {
+                    audioDetector.startListening()
+                }
+            } label: {
+                Label(
+                    audioDetector.isListening ? "Stop" : "Start",
+                    systemImage: audioDetector.isListening ? "stop.fill" : "mic.fill"
+                )
+                .font(.caption)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(audioDetector.isListening ? .red : .blue)
+            .disabled(!permissionGranted)
+
+            Button {
+                audioDetector.reset()
+            } label: {
+                Label("Reset", systemImage: "arrow.counterclockwise")
+                    .font(.caption)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    // MARK: - Settings Section
+
+    private var settingsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Detection Settings")
+                .font(.caption)
+                .fontWeight(.semibold)
+
+            // Threshold slider
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Onset Threshold: \(Int(audioDetector.onsetThresholdDb)) dB")
+                    .font(.system(size: 10))
+                Slider(value: $audioDetector.onsetThresholdDb, in: 5...30, step: 1)
+            }
+
+            // Refractory period
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Refractory: \(Int(audioDetector.refractoryPeriod * 1000)) ms")
+                    .font(.system(size: 10))
+                Slider(value: $audioDetector.refractoryPeriod, in: 0.1...0.5, step: 0.05)
+            }
+        }
+        .padding(8)
+        .background(Color(.darkGray).opacity(0.3))
+        .cornerRadius(8)
+    }
+}
+
+// MARK: - Level Meter Component
+
+struct LevelMeter: View {
+    let label: String
+    let valueDb: Float
+    let minDb: Float
+    let maxDb: Float
+    let thresholdDb: Float?
+
+    private var normalizedValue: CGFloat {
+        let clamped = max(minDb, min(maxDb, valueDb))
+        return CGFloat((clamped - minDb) / (maxDb - minDb))
+    }
+
+    private var normalizedThreshold: CGFloat? {
+        guard let threshold = thresholdDb else { return nil }
+        let clamped = max(minDb, min(maxDb, threshold))
+        return CGFloat((clamped - minDb) / (maxDb - minDb))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text(String(format: "%.0f dB", valueDb))
+                    .font(.system(size: 10, design: .monospaced))
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    // Background
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.gray.opacity(0.3))
+
+                    // Level bar
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(levelColor)
+                        .frame(width: geo.size.width * normalizedValue)
+
+                    // Threshold marker
+                    if let thresh = normalizedThreshold {
+                        Rectangle()
+                            .fill(Color.orange)
+                            .frame(width: 2)
+                            .offset(x: geo.size.width * thresh - 1)
+                    }
+                }
+            }
+            .frame(height: 16)
+        }
+    }
+
+    private var levelColor: Color {
+        if let thresh = thresholdDb, valueDb > thresh {
+            return .green
+        } else if valueDb > -20 {
+            return .yellow
+        } else {
+            return .blue
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AudioTestView()
+    }
+}

--- a/DhikrCounter Watch App/AudioTestView.swift
+++ b/DhikrCounter Watch App/AudioTestView.swift
@@ -4,8 +4,9 @@ import SwiftUI
 /// Use this to experiment with microphone-based click detection
 struct AudioTestView: View {
     @StateObject private var audioDetector = AudioPinchDetector()
+    @ObservedObject private var sessionManager = WatchSessionManager.shared
     @State private var permissionGranted = false
-    @State private var showingSettings = false
+    @State private var showingSettings = true  // Show settings by default for tuning
 
     var body: some View {
         ScrollView {
@@ -34,6 +35,23 @@ struct AudioTestView: View {
         .navigationTitle("Audio Test")
         .task {
             permissionGranted = await audioDetector.requestPermission()
+            loadSettingsFromPhone()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .tkeoSettingsUpdated)) { _ in
+            loadSettingsFromPhone()
+        }
+    }
+
+    /// Load audio settings synced from iPhone
+    private func loadSettingsFromPhone() {
+        if let threshold = sessionManager.getSetting("audio_thresholdDb") as? Double {
+            audioDetector.onsetThresholdDb = Float(threshold)
+        }
+        if let refractory = sessionManager.getSetting("audio_refractoryMs") as? Double {
+            audioDetector.refractoryPeriod = refractory / 1000.0
+        }
+        if let alpha = sessionManager.getSetting("audio_baselineAlpha") as? Double {
+            audioDetector.baselineAlpha = Float(alpha)
         }
     }
 
@@ -54,8 +72,9 @@ struct AudioTestView: View {
             Button {
                 showingSettings.toggle()
             } label: {
-                Image(systemName: "gear")
-                    .font(.caption)
+                Image(systemName: showingSettings ? "gear.circle.fill" : "gear.circle")
+                    .font(.title3)
+                    .foregroundColor(.blue)
             }
             .buttonStyle(.plain)
         }
@@ -86,12 +105,22 @@ struct AudioTestView: View {
 
     private var levelMetersSection: some View {
         VStack(spacing: 8) {
-            // Current level
+            // HPF mode indicator
+            HStack {
+                Image(systemName: audioDetector.useHighPassFilter ? "waveform.path.ecg" : "waveform")
+                    .foregroundColor(audioDetector.useHighPassFilter ? .cyan : .gray)
+                Text(audioDetector.useHighPassFilter ? "HPF+Peak" : "Raw RMS")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(audioDetector.useHighPassFilter ? .cyan : .gray)
+                Spacer()
+            }
+
+            // Current level - use wider range with HPF (baseline drops to ~-85dB)
             LevelMeter(
-                label: "Level",
+                label: audioDetector.useHighPassFilter ? "Peak" : "Level",
                 valueDb: audioDetector.currentRMSdB,
-                minDb: -60,
-                maxDb: 0,
+                minDb: audioDetector.useHighPassFilter ? -100 : -60,
+                maxDb: audioDetector.useHighPassFilter ? -20 : 0,
                 thresholdDb: audioDetector.baselineRMSdB + audioDetector.onsetThresholdDb
             )
 
@@ -102,10 +131,11 @@ struct AudioTestView: View {
                     .foregroundColor(.secondary)
                 Text(String(format: "%.0f dB", audioDetector.baselineRMSdB))
                     .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(audioDetector.baselineRMSdB < -80 ? .cyan : .primary)
 
                 Spacer()
 
-                Text("Threshold:")
+                Text("Thresh:")
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)
                 Text(String(format: "+%.0f dB", audioDetector.onsetThresholdDb))
@@ -178,11 +208,37 @@ struct AudioTestView: View {
                 .font(.caption)
                 .fontWeight(.semibold)
 
-            // Threshold slider
+            // HPF Toggle - NEW!
+            Toggle(isOn: $audioDetector.useHighPassFilter) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("High-Pass Filter")
+                        .font(.system(size: 10, weight: .medium))
+                    Text("Isolates click frequencies (3kHz+)")
+                        .font(.system(size: 8))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+
+            // Threshold slider - above baseline to trigger
             VStack(alignment: .leading, spacing: 2) {
-                Text("Onset Threshold: \(Int(audioDetector.onsetThresholdDb)) dB")
+                Text("Threshold: +\(Int(audioDetector.onsetThresholdDb)) dB above baseline")
                     .font(.system(size: 10))
-                Slider(value: $audioDetector.onsetThresholdDb, in: 5...30, step: 1)
+                Slider(value: $audioDetector.onsetThresholdDb, in: 2...20, step: 1)
+            }
+
+            // Jump threshold slider - Minimum sudden jump to trigger
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Min Jump: \(Int(audioDetector.minJumpDb)) dB (higher=stricter)")
+                    .font(.system(size: 10))
+                Slider(value: $audioDetector.minJumpDb, in: 5...25, step: 1)
+            }
+
+            // Max spike slider - Filter out loud ambient noise
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Max Spike: \(Int(audioDetector.maxSpikeDb)) dB (reject louder)")
+                    .font(.system(size: 10))
+                Slider(value: $audioDetector.maxSpikeDb, in: 20...50, step: 1)
             }
 
             // Refractory period

--- a/DhikrCounter Watch App/ContentView.swift
+++ b/DhikrCounter Watch App/ContentView.swift
@@ -54,22 +54,44 @@ struct SettingsListView: View {
     @ObservedObject private var sessionManager = WatchSessionManager.shared
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 8) {
-                // Header
-                HStack {
-                    Image(systemName: "gearshape.fill")
-                        .foregroundColor(.blue)
-                    Text("Settings")
-                        .font(.headline)
-                    Spacer()
-                    if sessionManager.tkeoSettingsReceived {
-                        Image(systemName: "checkmark.icloud.fill")
-                            .foregroundColor(.green)
-                            .font(.caption)
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    // Experimental: Audio Detection Test
+                    NavigationLink(destination: AudioTestView()) {
+                        HStack {
+                            Image(systemName: "waveform.circle.fill")
+                                .foregroundColor(.purple)
+                            Text("Audio Detection Test")
+                                .font(.caption)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                        .background(Color.purple.opacity(0.15))
+                        .cornerRadius(8)
                     }
-                }
-                .padding(.bottom, 4)
+                    .buttonStyle(.plain)
+
+                    Divider()
+
+                    // Header
+                    HStack {
+                        Image(systemName: "gearshape.fill")
+                            .foregroundColor(.blue)
+                        Text("Settings")
+                            .font(.headline)
+                        Spacer()
+                        if sessionManager.tkeoSettingsReceived {
+                            Image(systemName: "checkmark.icloud.fill")
+                                .foregroundColor(.green)
+                                .font(.caption)
+                        }
+                    }
+                    .padding(.bottom, 4)
 
                 // Last sync time
                 if let syncTime = sessionManager.lastSyncTime {
@@ -113,7 +135,8 @@ struct SettingsListView: View {
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-        }
+        }  // ScrollView
+        }  // NavigationStack
     }
 
     private var timeFormatter: DateFormatter {

--- a/DhikrCounter Watch App/Info.plist
+++ b/DhikrCounter Watch App/Info.plist
@@ -24,6 +24,8 @@
 	<string>This app uses HealthKit to run background workout sessions that keep the app active while collecting sensor data during dhikr sessions.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>This app uses HealthKit to run background workout sessions that keep the app active while collecting sensor data during dhikr sessions.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app uses the microphone to detect click sounds from finger rings or covers during dhikr counting. Audio is processed locally and never recorded or stored.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This app uses motion sensors to detect finger pinches during dhikr (Islamic prayer recitation) with research-validated accuracy.</string>
 	<key>UIBackgroundModes</key>

--- a/DhikrCounter Watch App/WatchSessionManager.swift
+++ b/DhikrCounter Watch App/WatchSessionManager.swift
@@ -487,6 +487,14 @@ extension WatchSessionManager: @preconcurrency WCSessionDelegate {
                 print("   - templateConfidence: \(nccThresh)")
             }
 
+            // Log audio settings
+            if let audioEnabled = tkeoSettings["audio_enabled"] as? Bool {
+                print("   - audio_enabled: \(audioEnabled)")
+            }
+            if let audioThreshold = tkeoSettings["audio_thresholdDb"] as? Double {
+                print("   - audio_thresholdDb: \(audioThreshold)")
+            }
+
             // Store current settings as previous for next comparison
             self.previousSettings = self.tkeoSettings
 
@@ -565,6 +573,11 @@ extension WatchSessionManager: @preconcurrency WCSessionDelegate {
             "tkeo_useTemplateValidation": "Template Valid."
         ]
         return names[key] ?? key.replacingOccurrences(of: "tkeo_", with: "")
+    }
+
+    /// Get a single setting value by key
+    func getSetting(_ key: String) -> Any? {
+        return tkeoSettings[key]
     }
 
     /// Get all current settings formatted for display, with recently changed ones first

--- a/DhikrCounter.xcodeproj/project.pbxproj
+++ b/DhikrCounter.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		F575EFAA2E86A100006F82C8 /* PinchTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575EFA82E86A100006F82C7 /* PinchTypes.swift */; };
 		F58368412ED6B8E00044F9A9 /* SettingsHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58368402ED6B8E00044F9A9 /* SettingsHelpView.swift */; };
 		F58368432ED6CABB0044F9A9 /* TemplateTrainingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58368422ED6CABB0044F9A9 /* TemplateTrainingView.swift */; };
+		F595E4672EE3CE5D00B1C918 /* AudioPinchDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F595E4652EE3CE5D00B1C918 /* AudioPinchDetector.swift */; };
+		F595E4682EE3CE5D00B1C918 /* AudioTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F595E4662EE3CE5D00B1C918 /* AudioTestView.swift */; };
 		F5991E902E66F499006885C5 /* DhikrCounter Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 31683209E7C5139A132FBBC6 /* DhikrCounter Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FAAC33ABD9E9A7C22A589960 /* WatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42F69224B2415F36C1294F4 /* WatchKit.framework */; };
 /* End PBXBuildFile section */
@@ -133,6 +135,8 @@
 		F575EFA82E86A100006F82C7 /* PinchTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchTypes.swift; sourceTree = "<group>"; };
 		F58368402ED6B8E00044F9A9 /* SettingsHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHelpView.swift; sourceTree = "<group>"; };
 		F58368422ED6CABB0044F9A9 /* TemplateTrainingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateTrainingView.swift; sourceTree = "<group>"; };
+		F595E4652EE3CE5D00B1C918 /* AudioPinchDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPinchDetector.swift; sourceTree = "<group>"; };
+		F595E4662EE3CE5D00B1C918 /* AudioTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTestView.swift; sourceTree = "<group>"; };
 		F657C64E8290259D316B999E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		FEDA213EFCDD446253B7B013 /* DataVisualizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataVisualizationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -211,6 +215,8 @@
 		8EC7B9FF2761149C94C0E39F /* DhikrCounter Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				F595E4652EE3CE5D00B1C918 /* AudioPinchDetector.swift */,
+				F595E4662EE3CE5D00B1C918 /* AudioTestView.swift */,
 				F531EB3A2E6CAB3500CCD0B6 /* DhikrCounter Watch App.entitlements */,
 				F505F6562E66C792003714BE /* WatchSessionManager.swift */,
 				955A2F5C2ABB7D9A3B6748A9 /* Assets.xcassets */,
@@ -383,6 +389,8 @@
 				43DCBBF8A1AB8FCDB652E389 /* DhikrSession.swift in Sources */,
 				2035D7153706B6A4E0B6A76A /* MilestoneView.swift in Sources */,
 				F575EFA92E86A100006F82C7 /* PinchTypes.swift in Sources */,
+				F595E4672EE3CE5D00B1C918 /* AudioPinchDetector.swift in Sources */,
+				F595E4682EE3CE5D00B1C918 /* AudioTestView.swift in Sources */,
 				692B0EA91BAB925090D459F0 /* SensorReading.swift in Sources */,
 				C01845AD9A84B3EABC33FB02 /* SessionView.swift in Sources */,
 				F575EFA72E86A100006F82C7 /* StreamingPinchDetector.swift in Sources */,

--- a/DhikrCounter/CompanionContentView.swift
+++ b/DhikrCounter/CompanionContentView.swift
@@ -474,7 +474,13 @@ struct SettingsView: View {
     @AppStorage("tkeo_madWinSec") private var madWinSec: Double = 3.0
     @AppStorage("tkeo_minWidthMs") private var minWidthMs: Double = 70
     @AppStorage("tkeo_maxWidthMs") private var maxWidthMs: Double = 350
-    
+
+    // Audio Detection Parameters
+    @AppStorage("audio_enabled") private var audioEnabled: Bool = false
+    @AppStorage("audio_thresholdDb") private var audioThresholdDb: Double = 3.0
+    @AppStorage("audio_refractoryMs") private var audioRefractoryMs: Double = 200
+    @AppStorage("audio_baselineAlpha") private var audioBaselineAlpha: Double = 0.05
+
     var body: some View {
         NavigationStack {
             List {
@@ -1097,13 +1103,63 @@ struct SettingsView: View {
                     .padding(.vertical, 4)
                 }
                 
+                Section("Audio Detection (Experimental)") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle(isOn: $audioEnabled) {
+                            VStack(alignment: .leading) {
+                                Text("Enable Audio Detection")
+                                Text("Use microphone to detect ring clicks")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        if audioEnabled {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text("Onset Threshold")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Text("+\(String(format: "%.1f", audioThresholdDb)) dB")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                                Text("Above baseline to trigger. Lower = more sensitive")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                Slider(value: $audioThresholdDb, in: 0.5...10.0, step: 0.5)
+                            }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text("Refractory Period")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Text("\(Int(audioRefractoryMs)) ms")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                                Text("Minimum time between detections")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                Slider(value: $audioRefractoryMs, in: 100...500, step: 50)
+                            }
+
+                            Text("Tap 'Sync Now' below to send settings to Watch")
+                                .font(.caption2)
+                                .foregroundColor(.blue)
+                                .padding(.top, 4)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
                 Section("Watch Sync") {
                     VStack(alignment: .leading, spacing: 8) {
                         HStack {
                             VStack(alignment: .leading) {
                                 Text("Sync Settings to Watch")
                                     .foregroundColor(.primary)
-                                Text("Send current TKEO parameters to Apple Watch")
+                                Text("Send current TKEO and Audio parameters to Apple Watch")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/DhikrCounter/PhoneSessionManager.swift
+++ b/DhikrCounter/PhoneSessionManager.swift
@@ -350,7 +350,13 @@ class PhoneSessionManager: NSObject, ObservableObject {
             "tkeo_minWidthMs": getDouble("tkeo_minWidthMs", fallback: 70),
             "tkeo_maxWidthMs": getDouble("tkeo_maxWidthMs", fallback: 350),
             "tkeo_windowPreMs": getDouble("tkeo_windowPreMs", fallback: 150),
-            "tkeo_windowPostMs": getDouble("tkeo_windowPostMs", fallback: 150)
+            "tkeo_windowPostMs": getDouble("tkeo_windowPostMs", fallback: 150),
+
+            // Audio Detection Parameters
+            "audio_enabled": defaults.object(forKey: "audio_enabled") != nil ? defaults.bool(forKey: "audio_enabled") : false,
+            "audio_thresholdDb": getDouble("audio_thresholdDb", fallback: 3.0),
+            "audio_refractoryMs": getDouble("audio_refractoryMs", fallback: 200),
+            "audio_baselineAlpha": getDouble("audio_baselineAlpha", fallback: 0.05)
         ]
 
         // Log key values being synced


### PR DESCRIPTION
## Summary
- Add 3kHz high-pass filter (Butterworth 2nd order) to isolate click frequencies from ambient noise
- Replace RMS energy with peak detection for better transient response to ring clicks
- Implement click fingerprint validation: spikes must decay within ~100ms (voice stays elevated)
- Add max spike filter to reject loud ambient noise (> 35dB)
- Use AND logic: require both threshold AND jump to trigger detection
- Add waitingForBaseline state to prevent false triggers after voice rejection
- Add UI controls on Watch: HPF toggle, min jump slider, max spike slider
- Sync audio settings from iPhone to Watch via WatchConnectivity

## Test plan
- [ ] Test in quiet environment - audio clicks should be detected reliably
- [ ] Test with voice sounds ("Hmm") - should be rejected as VOICE
- [ ] Test with loud ambient noise (door slam) - should be rejected as TOO_LOUD  
- [ ] Verify settings sync from iPhone to Watch
- [ ] Verify HPF toggle affects baseline levels (~-68dB raw vs ~-85dB with HPF)

## Related
Issue #48 - Investigate sound addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)